### PR TITLE
feat(log-middleware): implement log middleware

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,8 +1,9 @@
-import { Module, RequestMethod } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule, RequestMethod } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { LoggerModule } from 'nestjs-pino';
 import { randomBytes } from 'crypto';
+import { LoggerMiddleware } from './logger.middleware';
 
 @Module({
   imports: [LoggerModule.forRoot({
@@ -22,6 +23,9 @@ import { randomBytes } from 'crypto';
           req.body = req.raw.body;
           return req;
         },
+        res(res) {
+          return res;
+        },
       },
       redact: ["hostname"],
     },
@@ -30,4 +34,8 @@ import { randomBytes } from 'crypto';
   controllers: [AppController],
   providers: [AppService],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(LoggerMiddleware).forRoutes('/');
+  }
+}

--- a/src/logger.middleware.ts
+++ b/src/logger.middleware.ts
@@ -1,0 +1,11 @@
+import { Injectable, NestMiddleware, Logger } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+
+@Injectable()
+export class LoggerMiddleware implements NestMiddleware {
+  private logger = new Logger(LoggerMiddleware.name);
+  use(_req: Request, _res: Response, next: NextFunction) {
+    this.logger.log("Request received")
+    return next();
+  }
+}


### PR DESCRIPTION
This pull request shows how you can implement a simple logger middleware to have more context in your logs.

In this case, nest-js pino already logs completed/errored requests, but not "request received" logs.

In my experience, it is usefult to have a log pair to debug requests that perhaps are in-flight during a system crash or other catastrophic problem